### PR TITLE
Update the remote plugin devfile to use multicast discovery

### DIFF
--- a/che-in-che/che-theia-remote.devfile.yaml
+++ b/che-in-che/che-theia-remote.devfile.yaml
@@ -105,13 +105,24 @@ commands:
                  echo -e "\e[32mDone.\e[0m build ... hello-world-backend-plugin"
         workdir: /projects/che-theia-samples/samples/
   - 
-    name: run ... remote che plugin
+    name: run ... remote che plugin for current che-theia
     actions:
       - type: exec
         component: theia-endpoint-runtime
         command: >
                  killall node;
-                 echo export THEIA_PLUGIN_REMOTE_ENDPOINT_helloworld=\'ws://${HOSTNAME}:10000\' > /projects/endpoint.env &&
+                 export THEIA_PLUGINS='local-dir:///projects/che-theia-samples/samples/hello-world-backend-plugin' &&
+                 export THEIA_PLUGIN_ENDPOINT_PORT='10000' &&
+                 node /home/theia/lib/node/plugin-remote.js
+        workdir: /home/theia/
+  - 
+    name: run ... remote che plugin for new che-theia
+    actions:
+      - type: exec
+        component: theia-endpoint-runtime
+        command: >
+                 killall node;
+                 export THEIA_PLUGIN_ENDPOINT_DISCOVERY_PORT='2504' &&
                  export THEIA_PLUGINS='local-dir:///projects/che-theia-samples/samples/hello-world-backend-plugin' &&
                  export THEIA_PLUGIN_ENDPOINT_PORT='10000' &&
                  node /home/theia/lib/node/plugin-remote.js
@@ -122,9 +133,9 @@ commands:
       - type: exec
         component: theia-editor
         command: >
-                 kill `cat /tmp/node_theiadev.pid`;
+                 kill `cat /tmp/node_theiadev.pid` &> /dev/null;
                  mkdir -p /tmp/theiadev_projects &&
-                 . /projects/endpoint.env &&
+                 export THEIA_PLUGIN_ENDPOINT_DISCOVERY_PORT='2504' &&
                  export CHE_PROJECTS_ROOT=/tmp/theiadev_projects &&
                  node src-gen/backend/main.js /tmp/theiadev_projects --hostname=0.0.0.0 --port=3130 & echo $!> /tmp/node_theiadev.pid ; wait `cat /tmp/node_theiadev.pid`
         workdir: /projects/theia/production
@@ -136,7 +147,7 @@ commands:
         command: >
                  kill `cat /tmp/node_theiadev.pid`;
                  mkdir -p /tmp/theiadev_projects &&
-                 . /projects/endpoint.env &&
+                 export THEIA_PLUGIN_ENDPOINT_DISCOVERY_PORT='2504' &&
                  export CHE_PROJECTS_ROOT=/tmp/theiadev_projects &&
                  node src-gen/backend/main.js /tmp/theiadev_projects --hostname=0.0.0.0 --port=3130 & echo $!> /tmp/node_theiadev.pid ; wait `cat /tmp/node_theiadev.pid`
         workdir: /home/theia
@@ -149,7 +160,7 @@ commands:
                  killall node;
                  mkdir -p /tmp/theiadev_projects &&
                  export CHE_PROJECTS_ROOT=/tmp/theiadev_projects &&
-                 . /projects/endpoint.env &&
+                 export THEIA_PLUGIN_ENDPOINT_DISCOVERY_PORT='2504' &&
                  export GIT_EXEC_PATH=/usr/libexec/git-core && export USE_LOCAL_GIT=true && export LOCAL_GIT_DIRECTORY=/usr &&
                  yarn start /tmp/theiadev_projects --hostname=0.0.0.0 --port=3010
         workdir: /projects/theia/examples/assembly

--- a/che-in-che/che-theia-remote.devfile.yaml
+++ b/che-in-che/che-theia-remote.devfile.yaml
@@ -145,7 +145,7 @@ commands:
       - type: exec
         component: theia-editor
         command: >
-                 kill `cat /tmp/node_theiadev.pid`;
+                 kill `cat /tmp/node_theiadev.pid` &> /dev/null;
                  mkdir -p /tmp/theiadev_projects &&
                  export THEIA_PLUGIN_ENDPOINT_DISCOVERY_PORT='2504' &&
                  export CHE_PROJECTS_ROOT=/tmp/theiadev_projects &&

--- a/che-in-che/che-theia-remote.devfile.yaml
+++ b/che-in-che/che-theia-remote.devfile.yaml
@@ -59,6 +59,7 @@ components:
   - 
     id: che-incubator/typescript/1.30.2
     type: chePlugin
+    memoryLimit: 2048M    
 commands:
   - 
     name: init ... DEV che-theia


### PR DESCRIPTION
Update the remote plugin devfile to leverage the multicast discovery,
and give the ability to either run the remote plugin against the current Che Theia or against the new Che Theia (HOSTED or DEV) 